### PR TITLE
Pull request for changing block name and adding multilanguage header for payment details

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ If you are using a Content Security Policy (CSP) you must include different Unze
  ```
  composer require unzerdev/oxid7
  ```
+##### 2. Execute migration script to add database field OXUNZERPAYORDERNR to table oxorder
+```
+/vendor/bin/oe-eshop-db_migrate migrations:migrate
+```
+
 ##### 2. Provide write access to /var/ directory during execution
 
 ## Support

--- a/translations/de/unzerpayment_lang.php
+++ b/translations/de/unzerpayment_lang.php
@@ -13,7 +13,7 @@ $aLang = [
     'UNZER_PAYMENT_METHODNAME_GOOGLEPAY' => 'Google Pay',
     'UNZER_PAYMENT_METHODNAME_IDEAL' => 'iDEAL',
     'UNZER_PAYMENT_METHODNAME_KLARNA' => 'Klarna',
-    'UNZER_PAYMENT_METHODNAME_OPENBANKING_PIS' => 'Direktüberweisung',
+    'UNZER_PAYMENT_METHODNAME_OPENBANKING_PIS' => 'DirektÃ¼berweisung',
     'UNZER_PAYMENT_METHODNAME_PAYPAL' => 'PayPal',
     'UNZER_PAYMENT_METHODNAME_PAYU' => 'PayU',
     'UNZER_PAYMENT_METHODNAME_POST_FINANCE_CARD' => 'PostFinance Card',
@@ -29,7 +29,7 @@ $aLang = [
     'UNZER_PAYMENT_METHODNAME_WERO' => 'Wero',
     'UNZER_PAYMENT_METHODNAME_WECHATPAY' => 'WeChat Pay',
 
-    'UNZER_PLEASE_TRANSFER' => 'Bitte überweisen Sie den Betrag in Höhe von %s %s auf das folgende Konto:',
+    'UNZER_PLEASE_TRANSFER' => 'Bitte Ã¼berweisen Sie den Betrag in HÃ¶he von %s %s auf das folgende Konto:',
     'UNZER_HOLDER' => 'Kontoinhaber',
     'UNZER_IBAN' => 'IBAN',
     'UNZER_BIC' => 'BIC',

--- a/translations/de/unzerpayment_lang.php
+++ b/translations/de/unzerpayment_lang.php
@@ -34,6 +34,7 @@ $aLang = [
     'UNZER_IBAN' => 'IBAN',
     'UNZER_BIC' => 'BIC',
     'UNZER_PLEASE_USE_DESCRIPTOR' => 'Bitte nutzen Sie diese Identifikationsnummer als Verwendungszweck',
+    'UNZER_PAYMENT_DETAILS' => 'Zahlungsdaten fÃ¼r Ihre Bestellung',
 
 
 ];

--- a/translations/en/unzerpayment_lang.php
+++ b/translations/en/unzerpayment_lang.php
@@ -34,5 +34,6 @@ $aLang = [
     'UNZER_IBAN' => 'IBAN',
     'UNZER_BIC' => 'BIC',
     'UNZER_PLEASE_USE_DESCRIPTOR' => 'Please use only this identification number as the descriptor',
+    'UNZER_PAYMENT_DETAILS' => 'Payment details for your order',
 
 ];

--- a/views/twig/extensions/themes/default/page/checkout/inc/payment_other.html.twig
+++ b/views/twig/extensions/themes/default/page/checkout/inc/payment_other.html.twig
@@ -1,18 +1,30 @@
 <div class="payment-option" style="margin-bottom: 3px;">
     <div class="payment-option-form">
-        <input class="form-check-input" id="payment_{{ sPaymentID }}" type="radio" name="paymentid" value="{{ sPaymentID }}" {% if oView.getCheckedPaymentId() == paymentmethod.oxpayments__oxid.value %}checked{% endif %}>
-        <label class="form-check-label" for="payment_{{ sPaymentID }}">
-            <img src="{{ paymentmethod.getIcon() }}" style="max-width: 40px; height: auto; vertical-align: middle">
-            {{ paymentmethod.oxpayments__oxdesc.value }}
-        </label>
-    </div>
-    <div class="payment-option-info{% if oView.getCheckedPaymentId() == paymentmethod.oxpayments__oxid.value %} activePayment{% endif %}">
-        {% block checkout_payment_longdesc %}
-            {% if paymentmethod.oxpayments__oxlongdesc.value|striptags|trim %}
-                <div class="desc">
-                    {{ paymentmethod.oxpayments__oxlongdesc.getRawValue() }}
-                </div>
-            {% endif %}
-        {% endblock %}
+        <input class="form-check-input" id="payment_{{ sPaymentID }}" type="radio" name="paymentid"
+               value="{{ sPaymentID }}"{% if oView.getCheckedPaymentId() == paymentmethod.oxpayments__oxid.value %} checked{% endif %}>
+        <label class="form-check-label"
+               for="payment_{{ sPaymentID }}"><img src="{{ paymentmethod.getIcon() }}" style="max-width: 40px; height: auto; vertical-align: middle">{{ paymentmethod.oxpayments__oxdesc.value }}</label>
+
+        {% if paymentmethod.getDynValues() or paymentmethod.oxpayments__oxlongdesc.value|striptags|trim %}
+            <div class="payment-option-info{% if oView.getCheckedPaymentId() == paymentmethod.oxpayments__oxid.value %} activePayment{% endif %}">
+                {% for value in paymentmethod.getDynValues() %}
+                    <div class="form-floating mb-3">
+                        <input type="text" size="20"
+                               maxlength="64" name="dynvalue[{{ value.name }}]" value="{{ value.value }}"
+                               class="form-control" id="{{ sPaymentID }}_{{ loop.index }}"
+                               placeholder="name@example.com">
+                        <label for="{{ sPaymentID }}_{{ loop.index }}">{{ value.name }}</label>
+                    </div>
+                {% endfor %}
+
+                {% block checkout_payment_longdesc %}
+                    {% if paymentmethod.oxpayments__oxlongdesc.value|striptags|trim %}
+                        <div class="desc">
+                            {{ paymentmethod.oxpayments__oxlongdesc.value|raw }}
+                        </div>
+                    {% endif %}
+                {% endblock %}
+            </div>
+        {% endif %}
     </div>
 </div>

--- a/views/twig/extensions/themes/default/page/checkout/thankyou.html.twig
+++ b/views/twig/extensions/themes/default/page/checkout/thankyou.html.twig
@@ -2,13 +2,14 @@
 
 {% set sModuleId = '@' ~ constant('\\Unzer\\UnzerPayment\\Constants\\Constants::MODULE_ID') %}
 
-{% block checkout_thankyou_info %}
+{% block checkout_thankyou_payment_info %}
 
     {% if unzerPaymentId is defined %}
         <p style="font-style: italic">
             Unzer Payment-ID: {{ unzerPaymentId }}<br>
             Unzer Short-ID: {{ unzerShortId }}
         </p>
+        <h5><u>{{ translate({ ident: "UNZER_PAYMENT_DETAILS" }) }}</u></h5>
     {% endif %}
 
     {% if needsUnzerPaymentInfo is defined %}


### PR DESCRIPTION
I have changed the block name from {% block checkout_thankyou_info %} to {% block checkout_thankyou_payment_info %} to keep an consistent order in oxid eshop and added an multilingual header for the payment details. Maybe interesting to merge. Modyfied payment_other.html.twig to original APEX code as payment long descritions were not show with unzerdev original code