### PR TITLE
v1.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes for Unzer Payment Plugin for OXID eShop 7
 
+## [1.1.6]
+
+- Fixed an issue in the OXID webhook handler where incorrect shop scoping caused the wrong order ID to be resolved from a transaction ID, leading to orders not being completed or visible.
+
 ## [1.1.5]
 
 - Updated iDEAL Payment naming and logo

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
       "homepage": "https://www.unzer.com"
     }
   ],
-  "version": "1.1.5",
+  "version": "1.1.6",
   "license": "Apache-2.0",
   "extra": {
     "oxideshop": {

--- a/metadata.php
+++ b/metadata.php
@@ -16,7 +16,7 @@ $aModule = [
     ],
     'thumbnail' => 'admin/unzer_payment.png',
     'lang' => 'en',
-    'version' => '1.1.5',
+    'version' => '1.1.6',
     'author' => 'Unzer GmbH',
     'email' => 'info@unzer.com',
     'url' => 'https://www.unzer.com/',

--- a/src/Classes/UnzerpaymentHelper.php
+++ b/src/Classes/UnzerpaymentHelper.php
@@ -223,7 +223,9 @@ class UnzerpaymentHelper
             ->select('oxid')
             ->from('oxorder')
             ->where('oxtransid = :transactionId')
-            ->setParameter('transactionId', $transactionId);
+            ->andWhere('oxshopid = :oxshopid')
+            ->setParameter('transactionId', $transactionId)
+            ->setParameter('oxshopid', Registry::getConfig()->getShopId());
         $orderId = $queryBuilder->execute()->fetchColumn();
         return $orderId;
     }


### PR DESCRIPTION
* Fixed an issue in the OXID webhook handler where incorrect shop scoping caused the wrong order ID to be resolved from a transaction ID, leading to orders not being completed or visible